### PR TITLE
minimal pip install support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# IDE configs
+.idea/

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Python package to plot MCMC samples
 The latest version can be installed from the master branch using pip:
 
 ```
-pip install git+git://github.com/Volodymyrk/mcmcplotlib.git
+pip install git+git://github.com/mcmcplotlib/mcmcplotlib.git
 ```
 
 Another option is to clone the repository and install using `python setup.py install` or `python setup.py develop`.
-
+(Looking for a volunteer to register package on pypi/conda)
 
 ## Dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -3,9 +3,12 @@ from setuptools import setup, find_packages
 
 setup(
     name="mcmcplotlib",
-    version="1.0.0",
-    long_description=__doc__,
-    packages=find_packages(),
+    version="0.1.0",
+    packages=['mcmcplotlib'],
     include_package_data=True,
-    zip_safe=False,
+    install_requires=[
+        'matplotlib',
+        'numpy',
+        'scipy'
+    ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from distutils.core import setup
+
+setup(
+    name='mcmcplotlib',
+    version='0.0.1',
+    url='',
+    license='',
+    author='',
+    author_email='',
+    description='',
+    install_requires=[
+        'matplotlib',
+        'numpy',
+        'scipy'
+    ],
+)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 setup(
     name="mcmcplotlib",

--- a/setupegg.py
+++ b/setupegg.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python
+"""
+A setup.py script to use setuptools, which gives egg goodness, etc.
+"""
+
+from setuptools import setup
+with open('setup.py') as s:
+    exec(s.read())

--- a/setupegg.py
+++ b/setupegg.py
@@ -1,8 +1,0 @@
-#!/usr/bin/env python
-"""
-A setup.py script to use setuptools, which gives egg goodness, etc.
-"""
-
-from setuptools import setup
-with open('setup.py') as s:
-    exec(s.read())


### PR DESCRIPTION
If we want to make mcmcplotlib an (optional) dependancy for pymc3, we need to make it auto-installable with pymc3. 
Refactoring and testing are probably needed to be added, before making it a full dependancy.

As a first step, we can put a reference to:
 `pip install git+git://github.com/mcmcplotlib/mcmcplotlib.git` to pymc3 and start adding reference to mcmcplotlib in examples in pymc3.