### PR TITLE
Feature/round to string formatting

### DIFF
--- a/mcmcplotlib/hpd.py
+++ b/mcmcplotlib/hpd.py
@@ -2,7 +2,7 @@ from __future__ import division
 import numpy as np
 import scipy.stats.kde as kde
 
-def hpd_grid(sample, alpha=0.05, roundto=2):
+def hpd_grid(sample, alpha=0.05):
     """Calculate highest posterior density (HPD) of array for given alpha. 
     The HPD is the minimum width Bayesian credible interval (BCI). 
     The function works for multimodal distributions, returning more than one mode
@@ -14,8 +14,6 @@ def hpd_grid(sample, alpha=0.05, roundto=2):
         An array containing MCMC samples
     alpha : float
         Desired probability of type I error (defaults to 0.05)
-    roundto: integer
-        Number of digits after the decimal point for the results
 
     Returns
     ----------
@@ -30,7 +28,7 @@ def hpd_grid(sample, alpha=0.05, roundto=2):
     density = kde.gaussian_kde(sample)
     x = np.linspace(l, u, 2000)
     y = density.evaluate(x)
-    #y = density.evaluate(x, l, u) waitting for PR to be accepted
+    #y = density.evaluate(x, l, u) waiting for PR to be accepted
     xy_zipped = zip(x, y/np.sum(y))
     xy = sorted(xy_zipped, key=lambda x: x[1], reverse=True)
     xy_cum_sum = 0
@@ -43,17 +41,17 @@ def hpd_grid(sample, alpha=0.05, roundto=2):
     hdv.sort()
     diff = (u-l)/20  # differences of 5%
     hpd = []
-    hpd.append(round(min(hdv), roundto))
+    hpd.append(min(hdv))
     for i in range(1, len(hdv)):
         if hdv[i]-hdv[i-1] >= diff:
-            hpd.append(round(hdv[i-1], roundto))
-            hpd.append(round(hdv[i], roundto))
-    hpd.append(round(max(hdv), roundto))
+            hpd.append(hdv[i-1])
+            hpd.append(hdv[i])
+    hpd.append(max(hdv))
     ite = iter(hpd)
     hpd = list(zip(ite, ite))
     modes = []
     for value in hpd:
          x_hpd = x[(x > value[0]) & (x < value[1])]
          y_hpd = y[(x > value[0]) & (x < value[1])]
-         modes.append(round(x_hpd[np.argmax(y_hpd)], roundto))
+         modes.append(x_hpd[np.argmax(y_hpd)])
     return hpd, x, y, modes

--- a/mcmcplotlib/plot_post.py
+++ b/mcmcplotlib/plot_post.py
@@ -86,7 +86,8 @@ def plot_post(sample, alpha=0.05, show_mode=True, kde_plot=True, bins=50,
         pc_lt_comp_val = 100 - pc_gt_comp_val
         plt.axvline(comp_val, ymax=.75, color='g', linewidth=4, alpha=0.75,
             label='{:.{roundto}g}% < {:.{roundto}g} < {:.{roundto}g}%'.format(pc_lt_comp_val, 
-                                                                       comp_val, pc_gt_comp_val, roundto=roundto))
+                                                                              comp_val, pc_gt_comp_val, 
+                                                                              roundto=roundto))
         post_summary['comp_val'] = comp_val
         post_summary['pc_gt_comp_val'] = pc_gt_comp_val
 

--- a/mcmcplotlib/plot_post.py
+++ b/mcmcplotlib/plot_post.py
@@ -42,8 +42,8 @@ def plot_post(sample, alpha=0.05, show_mode=True, kde_plot=True, bins=50,
                    'hpd_high':0, 'comp_val':0, 'pc_gt_comp_val':0, 'ROPE_low':0,
                    'ROPE_high':0, 'pc_in_ROPE':0}
 
-    post_summary['mean'] = round(np.mean(sample), roundto)
-    post_summary['median'] = round(np.median(sample), roundto)
+    post_summary['mean'] = np.mean(sample)
+    post_summary['median'] = np.median(sample)
     post_summary['alpha'] = alpha
 
     # Compute the hpd, KDE and mode for the posterior
@@ -61,32 +61,32 @@ def plot_post(sample, alpha=0.05, show_mode=True, kde_plot=True, bins=50,
 
     ## Display mode or mean:
     if show_mode:
-        string = '{:g} ' * len(post_summary['mode'])
-        plt.plot(0, label='mode =' + string.format(*post_summary['mode']), alpha=0)
+        string = '{:.{roundto}g} '.format(roundto=roundto) * len(post_summary['mode'])
+        plt.plot(0, label='mode =' + string.format(*post_summary['mode']).rstrip(), alpha=0)
     else:
-        plt.plot(0, label='mean = {:g}'.format(post_summary['mean']), alpha=0)
+        plt.plot(0, label='mean = {:.{roundto}g}'.format(post_summary['mean'], roundto=roundto), alpha=0)
 
     ## Display the hpd.
     hpd_label = ''
     for value in hpd:
         plt.plot(value, [0, 0], linewidth=10, color='b')
-        hpd_label = hpd_label +  '{:g} {:g}\n'.format(round(value[0], roundto), round(value[1], roundto)) 
-    plt.plot(0, 0, linewidth=4, color='b', label='hpd {:g}%\n{}'.format((1-alpha)*100, hpd_label))
+        hpd_label = hpd_label +  '{:.{roundto}g} {:.{roundto}g}\n'.format(value[0], value[1], roundto=roundto) 
+    plt.plot(0, 0, linewidth=4, color='b', label='hpd {:.{roundto}g}%\n{}'.format((1-alpha)*100, hpd_label, roundto=roundto))
     ## Display the ROPE.
     if ROPE is not None:
-        pc_in_ROPE = round(np.sum((sample > ROPE[0]) & (sample < ROPE[1]))/len(sample)*100, roundto)
+        pc_in_ROPE = np.sum((sample > ROPE[0]) & (sample < ROPE[1]))/len(sample)*100
         plt.plot(ROPE, [0, 0], linewidth=20, color='r', alpha=0.75)
-        plt.plot(0, 0, linewidth=4, color='r', label='{:g}% in ROPE'.format(pc_in_ROPE))
+        plt.plot(0, 0, linewidth=4, color='r', label='{:.{roundto}g}% in ROPE'.format(pc_in_ROPE, roundto=roundto))
         post_summary['ROPE_low'] = ROPE[0] 
         post_summary['ROPE_high'] = ROPE[1] 
         post_summary['pc_in_ROPE'] = pc_in_ROPE
     ## Display the comparison value.
     if comp_val is not None:
-        pc_gt_comp_val = round(100 * np.sum(sample > comp_val)/len(sample), roundto)
-        pc_lt_comp_val = round(100 - pc_gt_comp_val, roundto)
+        pc_gt_comp_val = 100 * np.sum(sample > comp_val)/len(sample)
+        pc_lt_comp_val = 100 - pc_gt_comp_val
         plt.axvline(comp_val, ymax=.75, color='g', linewidth=4, alpha=0.75,
-            label='{:g}% < {:g} < {:g}%'.format(pc_lt_comp_val, 
-                                                comp_val, pc_gt_comp_val))
+            label='{:.{roundto}g}% < {:.{roundto}g} < {:.{roundto}g}%'.format(pc_lt_comp_val, 
+                                                                       comp_val, pc_gt_comp_val, roundto=roundto))
         post_summary['comp_val'] = comp_val
         post_summary['pc_gt_comp_val'] = pc_gt_comp_val
 

--- a/mcmcplotlib/plot_post.py
+++ b/mcmcplotlib/plot_post.py
@@ -61,22 +61,22 @@ def plot_post(sample, alpha=0.05, show_mode=True, kde_plot=True, bins=50,
 
     ## Display mode or mean:
     if show_mode:
-        string = '{:.{roundto}g} ' * len(post_summary['mode'])
-        plt.plot(0, label='mode =' + string.format(*post_summary['mode'], roundto=roundto).rstrip(), alpha=0)
+        string = '{:g} ' * len(post_summary['mode'])
+        plt.plot(0, label='mode =' + string.format(*[round(item, roundto) for item in post_summary['mode']]).rstrip(), alpha=0)
     else:
-        plt.plot(0, label='mean = {:.{roundto}g}'.format(post_summary['mean'], roundto=roundto), alpha=0)
+        plt.plot(0, label='mean = {:g}'.format(round(post_summary['mean'], roundto)), alpha=0)
 
     ## Display the hpd.
     hpd_label = ''
     for value in hpd:
         plt.plot(value, [0, 0], linewidth=10, color='b')
-        hpd_label = hpd_label +  '{:.{roundto}g} {:.{roundto}g}'.format(value[0], value[1], roundto=roundto) 
-    plt.plot(0, 0, linewidth=4, color='b', label='hpd {:.{roundto}g}%\n{}'.format((1-alpha)*100, hpd_label, roundto=roundto))
+        hpd_label = hpd_label +  '{:g} {:g}'.format(round(value[0], roundto), round(value[1], roundto)) 
+    plt.plot(0, 0, linewidth=4, color='b', label='hpd {:g}%\n{}'.format(round((1-alpha)*100, roundto), hpd_label))
     ## Display the ROPE.
     if ROPE is not None:
         pc_in_ROPE = np.sum((sample > ROPE[0]) & (sample < ROPE[1]))/len(sample)*100
         plt.plot(ROPE, [0, 0], linewidth=20, color='r', alpha=0.75)
-        plt.plot(0, 0, linewidth=4, color='r', label='{:.{roundto}g}% in ROPE'.format(pc_in_ROPE, roundto=roundto))
+        plt.plot(0, 0, linewidth=4, color='r', label='{:g}% in ROPE'.format(round(pc_in_ROPE, roundto)))
         post_summary['ROPE_low'] = ROPE[0] 
         post_summary['ROPE_high'] = ROPE[1] 
         post_summary['pc_in_ROPE'] = pc_in_ROPE
@@ -85,9 +85,9 @@ def plot_post(sample, alpha=0.05, show_mode=True, kde_plot=True, bins=50,
         pc_gt_comp_val = 100 * np.sum(sample > comp_val)/len(sample)
         pc_lt_comp_val = 100 - pc_gt_comp_val
         plt.axvline(comp_val, ymax=.75, color='g', linewidth=4, alpha=0.75,
-            label='{:.{roundto}g}% < {:.{roundto}g} < {:.{roundto}g}%'.format(pc_lt_comp_val, 
-                                                                              comp_val, pc_gt_comp_val, 
-                                                                              roundto=roundto))
+            label='{:g}% < {:g} < {:g}%'.format(round(pc_lt_comp_val, roundto), 
+                                                round(comp_val, roundto),
+                                                round(pc_gt_comp_val, roundto)))
         post_summary['comp_val'] = comp_val
         post_summary['pc_gt_comp_val'] = pc_gt_comp_val
 

--- a/mcmcplotlib/plot_post.py
+++ b/mcmcplotlib/plot_post.py
@@ -47,7 +47,7 @@ def plot_post(sample, alpha=0.05, show_mode=True, kde_plot=True, bins=50,
     post_summary['alpha'] = alpha
 
     # Compute the hpd, KDE and mode for the posterior
-    hpd, x, y, modes = hpd_grid(sample, alpha, roundto)
+    hpd, x, y, modes = hpd_grid(sample, alpha)
     post_summary['hpd'] = hpd
     post_summary['mode'] = modes
 

--- a/mcmcplotlib/plot_post.py
+++ b/mcmcplotlib/plot_post.py
@@ -61,8 +61,8 @@ def plot_post(sample, alpha=0.05, show_mode=True, kde_plot=True, bins=50,
 
     ## Display mode or mean:
     if show_mode:
-        string = '{:.{roundto}g} '.format(roundto=roundto) * len(post_summary['mode'])
-        plt.plot(0, label='mode =' + string.format(*post_summary['mode']).rstrip(), alpha=0)
+        string = '{:.{roundto}g} ' * len(post_summary['mode'])
+        plt.plot(0, label='mode =' + string.format(*post_summary['mode'], roundto=roundto).rstrip(), alpha=0)
     else:
         plt.plot(0, label='mean = {:.{roundto}g}'.format(post_summary['mean'], roundto=roundto), alpha=0)
 

--- a/mcmcplotlib/plot_post.py
+++ b/mcmcplotlib/plot_post.py
@@ -70,7 +70,7 @@ def plot_post(sample, alpha=0.05, show_mode=True, kde_plot=True, bins=50,
     hpd_label = ''
     for value in hpd:
         plt.plot(value, [0, 0], linewidth=10, color='b')
-        hpd_label = hpd_label +  '{:.{roundto}g} {:.{roundto}g}\n'.format(value[0], value[1], roundto=roundto) 
+        hpd_label = hpd_label +  '{:.{roundto}g} {:.{roundto}g}'.format(value[0], value[1], roundto=roundto) 
     plt.plot(0, 0, linewidth=4, color='b', label='hpd {:.{roundto}g}%\n{}'.format((1-alpha)*100, hpd_label, roundto=roundto))
     ## Display the ROPE.
     if ROPE is not None:


### PR DESCRIPTION
See issue #6

Changes:

in hpd.py
`roundto` keyword removed. No rounding is done.

in plot_post.py

all

    x = round(x, roundto)
    "{:g}".format(x)

are replaced with

    "{:g}".format(round(x, roundto))

This change prints `roundto` digits points after decimal point. 
Original idea of `"{:.{roundto}g}"` did not work. The rounding in this case was applied to `roundto` digits, which is not always the same as `roundto` digits points after decimal point.